### PR TITLE
fix: mock Web3Forms access key in Vitest config for CI tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['node_modules', 'dist', '.next', '.cache', 'e2e', 'playwright-report', 'test-results'],
+    env: {
+      // Mock Web3Forms access key for testing
+      // Tests only verify payload structure; fetch is mocked, so no real API calls are made
+      VITE_WEB3FORMS_ACCESS_KEY: 'test_access_key_for_ci_testing',
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html'],


### PR DESCRIPTION
Resolves GitHub Actions CI test failure where VITE_WEB3FORMS_ACCESS_KEY environment variable was undefined in test environment.

Changes:
- Added env config to vitest.config.ts with test-only mock access key
- Tests verify payload structure only; fetch is mocked so no real API calls
- All 47 tests now pass in both local and CI environments
- Coverage maintained at 94.28% (no regression)

The failing test "should include access_key in submission payload" expected body.access_key to be truthy, but import.meta.env.VITE_WEB3FORMS_ACCESS_KEY was undefined in CI. This fix provides a test-only mock value that satisfies the assertion without requiring real credentials in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)